### PR TITLE
minor updates to links

### DIFF
--- a/htdocs/faqs.html
+++ b/htdocs/faqs.html
@@ -51,7 +51,7 @@
 			This site will be updated on a weekly basis. 
                       </p>
                       <p>In addition to that, we are providing a Wikidata/GeneDB website. This has been rolled out for <em>Plasmodium</em> species. You can find more information 
-			<a href='https://tools.wmflabs.org/genedb' target='_blank'>here</a> and an example gene record page <a href='https://tools.wmflabs.org/genedb/#/gene/PF3D7_0810800' target='_blank'>here</a>.
+			<a href='https://www.genedb.org/#/wd' target='_blank'>here</a> and an example organism page <a href='https://www.genedb.org/#/species/Plasmodium_falciparum' target='_blank'>here</a>.
                       </p>
                     </div>
                   </div>

--- a/htdocs/includes/header.html
+++ b/htdocs/includes/header.html
@@ -35,7 +35,7 @@
               <a class="nav-link" href="/about.html">About us</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="https://apollo.genedb.org/jbrowse/">Apollo</a>
+              <a class="nav-link" href="https://apollo.genedb.org/jbrowse/" target="_blank">Apollo</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="https://www.genedb.org/action/BLAST">BLAST</a>

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -140,7 +140,7 @@
                 <div class="card-body">
                   <p class="card-text">GeneDB has been updated. You can now view gene structures and functional annotations in <a href='https://apollo.genedb.org/jbrowse/' target='_blank'>Apollo</a> 
 			which is based on <a href='https://jbrowse.org/' target='_blank'>JBrowse</a>. 
-			This site will be updated on a weekly basis. For more information, please see the <a href='./faqs.html' target='_blank'>FAQs</a>.
+			This site will be updated on a weekly basis. For more information, please see the <a href='./faqs.html'>FAQs</a>.
                   </p>
                 </div>
               </div>
@@ -155,7 +155,7 @@
                     Data
                     <span>
                       <i class="fas fa-angle-double-right card-link-icon"></i>
-                      <a href="data-release.html" target="_blank" class="card-link">Data Release Policy</a>
+                      <a href="data-release.html" class="card-link">Data Release Policy</a>
                     </span>
                   </p>
                   <p class="card-text">
@@ -168,13 +168,6 @@
                       <i class="fas fa-angle-double-right card-link-icon"></i>
                       <a href="https://www.sanger.ac.uk/science/tools/artemis" target="_blank" class="card-link">Artemis</a>
                     <span>
-                  </p>
-                  <p class="card-text">
-                    Mailing list
-                    <span>
-                      <i class="fas fa-angle-double-right card-link-icon"></i>
-                      <a href="http://lists.sanger.ac.uk/mailman/listinfo/genedb-info" target="_blank" class="card-link">Mailing list</a>
-                    </span>
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
RT 650336 - link updates

Minor things for the GeneDB front page/FAQs:
- would be better if the link to Apollo in the header opened a new tab (as in the "News")
- all links to internal pages should open in the same tab/window (link to FAQs in "News", link to Data release policy in "Information")
- remove link to mailing list in "Information" - the last mail was sent in 2015...
- FAQs, "What happened to the previous version of the GeneDB website?": Change the links, since the wd stuff is now hosted at Sanger ("main" page is https://www.genedb.org/#/wd). Can also link now to an organism page, e.g. https://www.genedb.org/#/species/Plasmodium_falciparum.