### PR TITLE
Convert index.html to vue.js component

### DIFF
--- a/htdocs/includes/header.html
+++ b/htdocs/includes/header.html
@@ -2,7 +2,7 @@
 <header id="header" class="header-wrapper">
 
     <!-- START LOGO -->
-    <div class="navbar-header" style='display:flex'>
+    <div class="navbar-header row">
       <div class='col-lg-9 col-md-12'>
         <a id="genedb-logo" class="navbar-brand" href="/" style='display:inline'>
           <img src="/img/GeneDB-logo.png" alt="GeneDB">

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -34,8 +34,8 @@
   <script src="js/jquery-3.3.1/jquery-3.3.1.min.js"></script>
   <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script> 
   <script src="js/bootstrap-4.0.0/bootstrap.bundle.min.js"></script>
-  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue/2.5.13/vue.min.js"></script>
-  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue-router/3.0.1/vue-router.min.js"></script>
+  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue/2.6.4/vue.min.js"></script>
+  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue-router/3.0.2/vue-router.min.js"></script>
   <script src="https://tools-static.wmflabs.org/tooltranslate/tt.js"></script>
   <script src="https://tools-static.wmflabs.org/magnustools/resources/js/wikidata.js"></script>
   <script src="https://tools-static.wmflabs.org/magnustools/resources/vue/shared.js"></script>

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -23,8 +23,8 @@
   <!-- WIKIDATA PARTS -->
   <link rel="stylesheet" href="https://tools-static.wmflabs.org/magnustools/resources/html/wikimedia.css">
   <link rel="stylesheet" href="/wd/custom.min.css">
-  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+  <script src="js/jquery-3.3.1/jquery-3.3.1.min.js"></script>
+  <script src="js/bootstrap-4.0.0/bootstrap.bundle.min.js"></script>
   <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue/2.5.13/vue.min.js"></script>
   <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue-router/3.0.1/vue-router.min.js"></script>
   <script src="https://tools-static.wmflabs.org/tooltranslate/tt.js"></script>
@@ -36,161 +36,10 @@
   <div id='app'>
     <router-view :key="$route.path"><i tt='loading'></i></router-view>
   </div>
-  <div id='main_body' class="container">
-    <!-- START MAIN WRAPPER -->
-    <div class="main-wrapper">
 
-      <!-- HEADER INCLUDE -->
-      <div class="include-me" id="header" data-location="./includes/header.html"></div>
-      <!-- START MAIN BODY CONTENT -->
-      <div class="main-content">
-        <div class="row">
-          <!-- START LEFT CONTENT -->
-          <div class="col-lg-9 col-md-12" id="mainLeftContent">
-            <div class="row">
-              <!-- START DATASET CONTAINER -->
-              <div class="col-lg-12" id="datasetContainer">
-                <h1>Datasets</h1>
-                <!-- START DATASET PANEL -->
-                <section class="dataset main-content-panel">
-                  <div class="bg-light-grey border-rounded">
-                    <div class="row">
-                      <!-- START Apicomplexan Protozoa -->
-                      <div class="col-lg-6 col-md-12">
-                        <div class="dataset-panel text-center" id="ApicomplexanProtozoaPanel">
-                          <h3 class="card-title">Apicomplexan Protozoa</h3>
-                          <img src="img/dataset-apicomplexan-protozoa.jpg" class="rounded mx-auto d-block" alt="apicomplexan protozoa">
-                          <div class="input-group">
-                            <select class="custom-select select-link form-control" id="apicomplexa">
-                              <option selected value="">Choose...</option>
-                            </select>
-                            <span class="input-group-btn">
-                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <!-- END Apicomplexan Protozoa -->
-                      <!-- START Kinetoplastid Protozoa -->
-                      <div class="col-lg-6 col-md-12">
-                        <div class="dataset-panel text-center" id="kinetoplastidProtozoaPanel">
-                          <h3 class="card-title">Kinetoplastid Protozoa</h3>
-                          <img src="img/dataset-kinetoplastid-protozoa.jpg" class="rounded mx-auto d-block" alt="kinetoplastid protozoa">
-                          <div class="input-group">
-                            <select class="custom-select select-link form-control" id="kinetoplastids">
-                              <option selected value="">Choose...</option>
-                            </select>
-                            <span class="input-group-btn">
-                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <!-- END Kinetoplastid Protozoa -->
-                    </div>
-                    <div class="row">
-                      <!-- START Parasitic Helminths -->
-                      <div class="col-lg-6 col-md-12">
-                        <div class="dataset-panel text-center" id="parasiticHelminthsPanel">
-                          <h3 class="card-title">Parasitic Helminths</h3>
-                          <img src="img/dataset-parasitic-helminths.jpg" class="rounded mx-auto d-block" alt="parasitic helminths">
-                          <div class="input-group">
-                            <select class="custom-select select-link form-control" id="helminths">
-                              <option selected value="">Choose...</option>
-                            </select>
-                            <span class="input-group-btn">
-                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <!-- END Parasitic Helminths -->
-                      <!-- START Fungi -->
-                      <div class="col-lg-6 col-md-12">
-                        <div class="dataset-panel text-center" id="fungiPanel">
-                          <h3 class="card-title">Fungi</h3>
-                          <img src="img/dataset-fungi.jpg" class="rounded mx-auto d-block" alt="fungi">
-                          <div class="input-group">
-                            <select class="custom-select select-link form-control" id="fungi">
-                              <option selected value="">Choose...</option>
-                              <option value="fungi">Fungi</option>
-                            </select>
-                            <span class="input-group-btn">
-                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <!-- END Fungi -->
-                    </div>
-                  </div>
-                </section>
-                <!-- END DATASET PANEL -->
-              </div>
-              <!-- END DATASET CONTAINER -->
-            </div>
-          </div>
-          <!-- END LEFT CONTENT -->
-          <!-- START RIGHT CONTENT -->
-          <div class="col-lg-3 col-md-12">
-            <!-- START NEWS -->
-            <section class="main-content-panel" id="newsSection">
-              <h1 class="card-title">News</h1>
-              <div class="card bg-light-grey border-rounded" id="news">
-                <div class="card-body">
-                  <p class="card-text">GeneDB has been updated. You can now view gene structures and functional annotations in <a href='https://apollo.genedb.org/jbrowse/' target='_blank'>Apollo</a> 
-			which is based on <a href='https://jbrowse.org/' target='_blank'>JBrowse</a>. 
-			This site will be updated on a weekly basis. For more information, please see the <a href='./faqs.html'>FAQs</a>.
-                  </p>
-                </div>
-              </div>
-            </section>
-            <!-- END NEWS -->
-            <!-- START INFORMATION -->
-            <section class="main-content-panel-last" id="informationSection">
-              <h1 class="card-title">Information</h1>
-              <div class="card bg-light-blue border-rounded" id="information">
-                <div class="card-body">
-                  <p class="card-text">
-                    Data
-                    <span>
-                      <i class="fas fa-angle-double-right card-link-icon"></i>
-                      <a href="data-release.html" class="card-link">Data Release Policy</a>
-                    </span>
-                  </p>
-                  <p class="card-text">
-                    Software
-                    <span>
-                      <i class="fas fa-angle-double-right card-link-icon"></i>
-                      <a href="https://www.sanger.ac.uk/science/tools/artemis-comparison-tool-act" target="_blank" class="card-link">ACT</a>
-                    </span>
-                    <span>
-                      <i class="fas fa-angle-double-right card-link-icon"></i>
-                      <a href="https://www.sanger.ac.uk/science/tools/artemis" target="_blank" class="card-link">Artemis</a>
-                    <span>
-                  </p>
-                </div>
-              </div>
-            </section>
-            <!-- END INFORMATION -->
-          </div>
-          <!-- END RIGHT CONTENT -->
-        </div>
-      </div>
-      <!-- END MAIN BODY CONTENT -->
-
-      <!-- FOOTER INCLUDE -->
-      <div class="include-me" id="footer" data-location="./includes/footer.html"></div>
-    </div>
-    <!-- END MAIN WRAPPER -->
-  </div>
   <!-- SCRIPTS -->
-  <!-- jQuery 3.3.1 -->
-  <script src="js/jquery-3.3.1/jquery-3.3.1.min.js"></script>
-  <!-- Bootstrap 4.0.0 -->
-  <script src="js/bootstrap-4.0.0/bootstrap.min.js"></script>
   <!-- Custom -->
-  <script src="js/custom.min.js"></script>
+<!--  <script src="js/custom.min.js"></script>-->
   <!-- Wikidata -->
   <script src="wd/vue.js"></script>
 </body>

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -23,13 +23,6 @@
   <!-- WIKIDATA PARTS -->
   <link rel="stylesheet" href="https://tools-static.wmflabs.org/magnustools/resources/html/wikimedia.css">
   <link rel="stylesheet" href="/wd/custom.min.css">
-  <script src="js/jquery-3.3.1/jquery-3.3.1.min.js"></script>
-  <script src="js/bootstrap-4.0.0/bootstrap.bundle.min.js"></script>
-  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue/2.5.13/vue.min.js"></script>
-  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue-router/3.0.1/vue-router.min.js"></script>
-  <script src="https://tools-static.wmflabs.org/tooltranslate/tt.js"></script>
-  <script src="https://tools-static.wmflabs.org/magnustools/resources/js/wikidata.js"></script>
-  <script src="https://tools-static.wmflabs.org/magnustools/resources/vue/shared.js"></script>
 </head>
 
 <body class="body-wrapper static">
@@ -38,9 +31,15 @@
   </div>
 
   <!-- SCRIPTS -->
-  <!-- Custom -->
-<!--  <script src="js/custom.min.js"></script>-->
-  <!-- Wikidata -->
+  <script src="js/jquery-3.3.1/jquery-3.3.1.min.js"></script>
+  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script> 
+  <script src="js/bootstrap-4.0.0/bootstrap.bundle.min.js"></script>
+  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue/2.5.13/vue.min.js"></script>
+  <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue-router/3.0.1/vue-router.min.js"></script>
+  <script src="https://tools-static.wmflabs.org/tooltranslate/tt.js"></script>
+  <script src="https://tools-static.wmflabs.org/magnustools/resources/js/wikidata.js"></script>
+  <script src="https://tools-static.wmflabs.org/magnustools/resources/vue/shared.js"></script>
   <script src="wd/vue.js"></script>
+
 </body>
 </html>

--- a/htdocs/wd/genedb_header.html
+++ b/htdocs/wd/genedb_header.html
@@ -30,18 +30,20 @@ Vue.component ( 'genedb-header' , {
   } ,
 	methods : {
     addSearch : function () {
-      if ( this.search_added ) return ;
-      if ( this.is_loaded && $("#search-form").length > 0 ) {
+      let me = this ;
+      if ( me.search_added ) return ;
+      if ( me.is_loaded && $("#search-form").length > 0 ) {
         $("#search-form-find").keydown ( function () { $("#search-form-button").removeClass('disabled') });
         $("#search-form").submit(function() {
             var query = $('input[name="find"]').val();
-            window.location.href = '/#/search/'+query;
+            me.$router.push ( '/search/'+encodeURIComponent(query) );
+//            window.location.href = '/#/search/'+query;
             return false;
         });
-        this.search_added = true ;
+        me.search_added = true ;
         return ;
       }
-      setTimeout ( this.addSearch , 100 ) ;
+      setTimeout ( me.addSearch , 100 ) ;
     }
 	}
 } ) ;

--- a/htdocs/wd/index_page.html
+++ b/htdocs/wd/index_page.html
@@ -19,73 +19,27 @@
                 <section class="dataset main-content-panel">
                   <div class="bg-light-grey border-rounded">
                     <div class="row">
-                      <!-- START Apicomplexan Protozoa -->
-                      <div class="col-lg-6 col-md-12">
-                        <div class="dataset-panel text-center" id="ApicomplexanProtozoaPanel">
-                          <h3 class="card-title">Apicomplexan Protozoa</h3>
-                          <img src="img/dataset-apicomplexan-protozoa.jpg" class="rounded mx-auto d-block" alt="apicomplexan protozoa">
+
+                    <!-- START SPECIES GROUP BOXES -->
+                      <div v-for='(data,id) in groups' class="col-lg-6 col-md-12">
+                        <div class="dataset-panel text-center" :id="data.name.replace(/\s+/g,'')+'Panel'">
+                          <h3 class="card-title">{{data.name}}</h3>
+                          <img :src="data.img_src" class="rounded mx-auto d-block" :alt="data.img_src.replace(/^.*\//,'').replace(/\.[a-z]+$/,'')">
                           <div class="input-group">
-                            <select class="custom-select select-link form-control" id="apicomplexa">
+                            <select class="custom-select select-link form-control" :id="id" @change='onSelect(this,id)' v-model='data.selection'>
                               <option selected value="">Choose...</option>
+                              <option v-for='entry in data.entries' :value='entry.value'>
+                              	{{entry.key}}
+                              </option>
                             </select>
                             <span class="input-group-btn">
-                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
+                              <a href="#" target="_blank" :id="id+'_button'" class="btn btn-dark custom-button disabled">Go</a>
                             </span>
                           </div>
                         </div>
                       </div>
-                      <!-- END Apicomplexan Protozoa -->
-                      <!-- START Kinetoplastid Protozoa -->
-                      <div class="col-lg-6 col-md-12">
-                        <div class="dataset-panel text-center" id="kinetoplastidProtozoaPanel">
-                          <h3 class="card-title">Kinetoplastid Protozoa</h3>
-                          <img src="img/dataset-kinetoplastid-protozoa.jpg" class="rounded mx-auto d-block" alt="kinetoplastid protozoa">
-                          <div class="input-group">
-                            <select class="custom-select select-link form-control" id="kinetoplastids">
-                              <option selected value="">Choose...</option>
-                            </select>
-                            <span class="input-group-btn">
-                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <!-- END Kinetoplastid Protozoa -->
-                    </div>
-                    <div class="row">
-                      <!-- START Parasitic Helminths -->
-                      <div class="col-lg-6 col-md-12">
-                        <div class="dataset-panel text-center" id="parasiticHelminthsPanel">
-                          <h3 class="card-title">Parasitic Helminths</h3>
-                          <img src="img/dataset-parasitic-helminths.jpg" class="rounded mx-auto d-block" alt="parasitic helminths">
-                          <div class="input-group">
-                            <select class="custom-select select-link form-control" id="helminths">
-                              <option selected value="">Choose...</option>
-                            </select>
-                            <span class="input-group-btn">
-                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <!-- END Parasitic Helminths -->
-                      <!-- START Fungi -->
-                      <div class="col-lg-6 col-md-12">
-                        <div class="dataset-panel text-center" id="fungiPanel">
-                          <h3 class="card-title">Fungi</h3>
-                          <img src="img/dataset-fungi.jpg" class="rounded mx-auto d-block" alt="fungi">
-                          <div class="input-group">
-                            <select class="custom-select select-link form-control" id="fungi">
-                              <option selected value="">Choose...</option>
-                              <option value="fungi">Fungi</option>
-                            </select>
-                            <span class="input-group-btn">
-                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <!-- END Fungi -->
+                      <!-- END SPECIES GROUP BOXES -->
+
                     </div>
                   </div>
                 </section>
@@ -155,60 +109,59 @@
 'use strict';
 
 let IndexPage = Vue.extend ( {
-	data : function () { return { group_options:{} } } ,
+	data : function () { return { groups:{
+		apicomplexa:{entries:[],name:'Apicomplexan Protozoa',img_src:'img/dataset-apicomplexan-protozoa.jpg'},
+		kinetoplastids:{entries:[],name:'Kinetoplastid Protozoa',img_src:'img/dataset-kinetoplastid-protozoa.jpg'},
+		helminths:{entries:[],name:'Parasitic Helminths',img_src:'img/dataset-parasitic-helminths.jpg'},
+		fungi:{entries:[],name:'Fungi',img_src:'img/dataset-fungi.jpg'},
+	} } } ,
 	created : function () {
 	} ,
 	mounted : function () {
 		this.loadDatasets () ;
-		this.fixLayout() ;
+//		this.fixLayout() ;
 	} ,
 	methods : {
 		loadDatasets : function () {
-		  $.get("data/datasets.json", function( data ){ 
-		    $.each(data, function(name, values) {
+			let me = this ;
+			$.get("data/datasets.json", function( data ){ 
+				$.each(data, function(name, values) {
 
-		      let output = [];
+				  let output = [];
 
-		      $.each(values, function(index, value){
-		        let key = value.genus + ' ' + value.species;
-		        output.push({ key: key, value: value.common_name});
-		      });
+				  $.each(values, function(index, value){
+				    let key = value.genus + ' ' + value.species;
+				    output.push({ key: key, value: value.common_name});
+				  });
 
-		      output = output.sort(function (a, b) {
-		          return a.value.localeCompare( b.value );
-		      });
+				  output = output.sort(function (a, b) {
+				      return a.value.localeCompare( b.value );
+				  });
 
-		      me.group_options[name] = output ;
+				  if ( typeof me.groups[name] == 'undefined' ) me.groups[name] = { name:name } ; // Fallback: dummy fill
 
-		      let select = $('#'+name);
-
-		      select.empty();
-		      select.append('<option value="">Choose...</option>');
-
-		      $.each(output, function(key, value) {
-		        select.append('<option value="' + value.value + '">' + value.key + '</option>');
-		      });
-		    });
-		  });
+				  me.groups[name].selection = '' ;
+				  me.groups[name].entries = output ;
+				});
+			});
 		} ,
-		fixLayout : function () {
-		  // Forward main content selected option to apollo
-		  $('.select-link').on('change', function(){
-		    let select = $(this);
-		    $('.select-link').not(select).val('');
-		    $('.custom-button').addClass('disabled').attr('href', '#');
-		    let dataset = select.parent();
-		    let link = $('a', dataset);
-		    if( select.attr('id') == 'parasiteVectors') {
-		      link.attr('href', 'parasite-vectors.html');
-		    } else {
-		      link.attr('href', 'https://apollo.genedb.org/'+select.val()+'/jbrowse/index.html?tracks=DNA%2CAnnotations%2Cgene%2CmRNA&highlight=');
-		    }
-		    if( select.val() != '' ){
-		      link.removeClass('disabled');
-		    }
+		onSelect : function ( o , id ) {
+			let me = this ;
+			let select = $(o);
 
-		  });
+			$.each ( me.groups , function ( k , v ) {
+				if(id==k) return; 
+				Vue.set ( me.groups[k] , 'selection' , '' ) ; 
+				$('#'+k).val('') ;
+			} ) ; // Reset all other selections
+
+			$('.custom-button') // Reset all buttons
+				.addClass('disabled')
+				.attr('href', '#');
+			if ( me.groups[id].selection == '' ) return ; // No selection, leave button deactivated
+			$('#'+id+'_button') // Set go button
+				.removeClass('disabled')
+				.attr('href', 'https://apollo.genedb.org/'+me.groups[id].selection+'/jbrowse/index.html?tracks=DNA%2CAnnotations%2Cgene%2CmRNA&highlight=');
 		}
 	} ,
 	template : '#index-page-template'

--- a/htdocs/wd/index_page.html
+++ b/htdocs/wd/index_page.html
@@ -1,0 +1,217 @@
+<template id='index-page-template'>
+<div id='main_body' class='container'>
+
+    <!-- START MAIN WRAPPER -->
+    <div class="main-wrapper">
+
+      <!-- HEADER INCLUDE -->
+		<genedb-header></genedb-header>
+      <!-- START MAIN BODY CONTENT -->
+      <div class="main-content">
+        <div class="row">
+          <!-- START LEFT CONTENT -->
+          <div class="col-lg-9 col-md-12" id="mainLeftContent">
+            <div class="row">
+              <!-- START DATASET CONTAINER -->
+              <div class="col-lg-12" id="datasetContainer">
+                <h1>Datasets</h1>
+                <!-- START DATASET PANEL -->
+                <section class="dataset main-content-panel">
+                  <div class="bg-light-grey border-rounded">
+                    <div class="row">
+                      <!-- START Apicomplexan Protozoa -->
+                      <div class="col-lg-6 col-md-12">
+                        <div class="dataset-panel text-center" id="ApicomplexanProtozoaPanel">
+                          <h3 class="card-title">Apicomplexan Protozoa</h3>
+                          <img src="img/dataset-apicomplexan-protozoa.jpg" class="rounded mx-auto d-block" alt="apicomplexan protozoa">
+                          <div class="input-group">
+                            <select class="custom-select select-link form-control" id="apicomplexa">
+                              <option selected value="">Choose...</option>
+                            </select>
+                            <span class="input-group-btn">
+                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      <!-- END Apicomplexan Protozoa -->
+                      <!-- START Kinetoplastid Protozoa -->
+                      <div class="col-lg-6 col-md-12">
+                        <div class="dataset-panel text-center" id="kinetoplastidProtozoaPanel">
+                          <h3 class="card-title">Kinetoplastid Protozoa</h3>
+                          <img src="img/dataset-kinetoplastid-protozoa.jpg" class="rounded mx-auto d-block" alt="kinetoplastid protozoa">
+                          <div class="input-group">
+                            <select class="custom-select select-link form-control" id="kinetoplastids">
+                              <option selected value="">Choose...</option>
+                            </select>
+                            <span class="input-group-btn">
+                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      <!-- END Kinetoplastid Protozoa -->
+                    </div>
+                    <div class="row">
+                      <!-- START Parasitic Helminths -->
+                      <div class="col-lg-6 col-md-12">
+                        <div class="dataset-panel text-center" id="parasiticHelminthsPanel">
+                          <h3 class="card-title">Parasitic Helminths</h3>
+                          <img src="img/dataset-parasitic-helminths.jpg" class="rounded mx-auto d-block" alt="parasitic helminths">
+                          <div class="input-group">
+                            <select class="custom-select select-link form-control" id="helminths">
+                              <option selected value="">Choose...</option>
+                            </select>
+                            <span class="input-group-btn">
+                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      <!-- END Parasitic Helminths -->
+                      <!-- START Fungi -->
+                      <div class="col-lg-6 col-md-12">
+                        <div class="dataset-panel text-center" id="fungiPanel">
+                          <h3 class="card-title">Fungi</h3>
+                          <img src="img/dataset-fungi.jpg" class="rounded mx-auto d-block" alt="fungi">
+                          <div class="input-group">
+                            <select class="custom-select select-link form-control" id="fungi">
+                              <option selected value="">Choose...</option>
+                              <option value="fungi">Fungi</option>
+                            </select>
+                            <span class="input-group-btn">
+                              <a href="#" target="_blank" class="btn btn-dark custom-button disabled">Go</a>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      <!-- END Fungi -->
+                    </div>
+                  </div>
+                </section>
+                <!-- END DATASET PANEL -->
+              </div>
+              <!-- END DATASET CONTAINER -->
+            </div>
+          </div>
+          <!-- END LEFT CONTENT -->
+          <!-- START RIGHT CONTENT -->
+          <div class="col-lg-3 col-md-12">
+            <!-- START NEWS -->
+            <section class="main-content-panel" id="newsSection">
+              <h1 class="card-title">News</h1>
+              <div class="card bg-light-grey border-rounded" id="news">
+                <div class="card-body">
+                  <p class="card-text">GeneDB has been updated. You can now view gene structures and functional annotations in <a href='https://apollo.genedb.org/jbrowse/' target='_blank'>Apollo</a> 
+			which is based on <a href='https://jbrowse.org/' target='_blank'>JBrowse</a>. 
+			This site will be updated on a weekly basis. For more information, please see the <a href='./faqs.html'>FAQs</a>.
+                  </p>
+                </div>
+              </div>
+            </section>
+            <!-- END NEWS -->
+            <!-- START INFORMATION -->
+            <section class="main-content-panel-last" id="informationSection">
+              <h1 class="card-title">Information</h1>
+              <div class="card bg-light-blue border-rounded" id="information">
+                <div class="card-body">
+                  <p class="card-text">
+                    Data
+                    <span>
+                      <i class="fas fa-angle-double-right card-link-icon"></i>
+                      <a href="data-release.html" class="card-link">Data Release Policy</a>
+                    </span>
+                  </p>
+                  <p class="card-text">
+                    Software
+                    <span>
+                      <i class="fas fa-angle-double-right card-link-icon"></i>
+                      <a href="https://www.sanger.ac.uk/science/tools/artemis-comparison-tool-act" target="_blank" class="card-link">ACT</a>
+                    </span>
+                    <span>
+                      <i class="fas fa-angle-double-right card-link-icon"></i>
+                      <a href="https://www.sanger.ac.uk/science/tools/artemis" target="_blank" class="card-link">Artemis</a>
+                    <span>
+                  </p>
+                </div>
+              </div>
+            </section>
+            <!-- END INFORMATION -->
+          </div>
+          <!-- END RIGHT CONTENT -->
+        </div>
+      </div>
+      <!-- END MAIN BODY CONTENT -->
+
+      <!-- FOOTER INCLUDE -->
+		<genedb-footer></genedb-footer>
+    </div>
+    <!-- END MAIN WRAPPER -->
+  
+</div>
+</template>
+
+<script>
+'use strict';
+
+let IndexPage = Vue.extend ( {
+	data : function () { return { group_options:{} } } ,
+	created : function () {
+	} ,
+	mounted : function () {
+		this.loadDatasets () ;
+		this.fixLayout() ;
+	} ,
+	methods : {
+		loadDatasets : function () {
+		  $.get("data/datasets.json", function( data ){ 
+		    $.each(data, function(name, values) {
+
+		      let output = [];
+
+		      $.each(values, function(index, value){
+		        let key = value.genus + ' ' + value.species;
+		        output.push({ key: key, value: value.common_name});
+		      });
+
+		      output = output.sort(function (a, b) {
+		          return a.value.localeCompare( b.value );
+		      });
+
+		      me.group_options[name] = output ;
+
+		      let select = $('#'+name);
+
+		      select.empty();
+		      select.append('<option value="">Choose...</option>');
+
+		      $.each(output, function(key, value) {
+		        select.append('<option value="' + value.value + '">' + value.key + '</option>');
+		      });
+		    });
+		  });
+		} ,
+		fixLayout : function () {
+		  // Forward main content selected option to apollo
+		  $('.select-link').on('change', function(){
+		    let select = $(this);
+		    $('.select-link').not(select).val('');
+		    $('.custom-button').addClass('disabled').attr('href', '#');
+		    let dataset = select.parent();
+		    let link = $('a', dataset);
+		    if( select.attr('id') == 'parasiteVectors') {
+		      link.attr('href', 'parasite-vectors.html');
+		    } else {
+		      link.attr('href', 'https://apollo.genedb.org/'+select.val()+'/jbrowse/index.html?tracks=DNA%2CAnnotations%2Cgene%2CmRNA&highlight=');
+		    }
+		    if( select.val() != '' ){
+		      link.removeClass('disabled');
+		    }
+
+		  });
+		}
+	} ,
+	template : '#index-page-template'
+} ) ;
+
+</script>

--- a/htdocs/wd/index_page.html
+++ b/htdocs/wd/index_page.html
@@ -2,7 +2,9 @@
 <div id='main_body' class='container'>
 
     <!-- START MAIN WRAPPER -->
-    <div class="main-wrapper">
+    <div v-if="loading" class="main-wrapper">
+    </div>
+    <div v-else class="main-wrapper">
 
       <!-- HEADER INCLUDE -->
 		<genedb-header></genedb-header>
@@ -109,17 +111,17 @@
 'use strict';
 
 let IndexPage = Vue.extend ( {
-	data : function () { return { groups:{
+	data : function () { return { loading:true , groups:{
 		apicomplexa:{entries:[],name:'Apicomplexan Protozoa',img_src:'img/dataset-apicomplexan-protozoa.jpg'},
 		kinetoplastids:{entries:[],name:'Kinetoplastid Protozoa',img_src:'img/dataset-kinetoplastid-protozoa.jpg'},
 		helminths:{entries:[],name:'Parasitic Helminths',img_src:'img/dataset-parasitic-helminths.jpg'},
 		fungi:{entries:[],name:'Fungi',img_src:'img/dataset-fungi.jpg'},
 	} } } ,
 	created : function () {
+		history.pushState("", document.title, window.location.pathname + window.location.search); // Remove hash from URL
 	} ,
 	mounted : function () {
 		this.loadDatasets () ;
-//		this.fixLayout() ;
 	} ,
 	methods : {
 		loadDatasets : function () {
@@ -134,26 +136,25 @@ let IndexPage = Vue.extend ( {
 				    output.push({ key: key, value: value.common_name});
 				  });
 
-				  output = output.sort(function (a, b) {
+				  if ( typeof me.groups[name] == 'undefined' ) me.groups[name] = { name:name } ; // Fallback: dummy fill
+				  me.groups[name].selection = '' ;
+				  me.groups[name].entries = output.sort(function (a, b) {
 				      return a.value.localeCompare( b.value );
 				  });
-
-				  if ( typeof me.groups[name] == 'undefined' ) me.groups[name] = { name:name } ; // Fallback: dummy fill
-
-				  me.groups[name].selection = '' ;
-				  me.groups[name].entries = output ;
 				});
 			});
+			me.loading = false ;
 		} ,
 		onSelect : function ( o , id ) {
 			let me = this ;
 			let select = $(o);
 
+			// Reset all other selections
 			$.each ( me.groups , function ( k , v ) {
 				if(id==k) return; 
 				Vue.set ( me.groups[k] , 'selection' , '' ) ; 
 				$('#'+k).val('') ;
-			} ) ; // Reset all other selections
+			} ) ;
 
 			$('.custom-button') // Reset all buttons
 				.addClass('disabled')

--- a/htdocs/wd/vue.js
+++ b/htdocs/wd/vue.js
@@ -33,6 +33,7 @@ $(document).ready ( function () {
 	] )	.then ( () => {
 			wd_link_wd = wd ;
 			const routes = [
+			  { path: '', component: IndexPage , props:true },
 			  { path: '/', component: IndexPage , props:true },
 			  { path: '/wd', component: MainPage , props:true },
 			  { path: '/gene/:genedb_id', component: Gene , props:true },
@@ -44,7 +45,7 @@ $(document).ready ( function () {
 			  { path: '/species/:species_id', component: SpeciesPage , props:true },
 			  { path: '/chromosome/:q_chromosome', component: Chromosome , props:true },
 			] ;
-			router = new VueRouter({routes}) ;
+			router = new VueRouter({routes}) ; // mode: 'history',
 			app = new Vue ( { router } ) .$mount('#app') ;
 		} ) ;
 } ) ;

--- a/htdocs/wd/vue.js
+++ b/htdocs/wd/vue.js
@@ -6,7 +6,7 @@ let wd = new WikiData() ;
 
 
 $(document).ready ( function () {
-	if ( window.location.hash=='' || window.location.hash=='#' ) return ;
+//	if ( window.location.hash=='' || window.location.hash=='#' ) return ;
 	$('#app').show() ;
 	$('#main_body').hide() ;
 	vue_components.toolname = 'genedb' ;
@@ -17,6 +17,7 @@ $(document).ready ( function () {
 			'/wd/genedb_header.html',
 			'/wd/genedb_footer.html',
 			'/wd/main_page.html',
+			'/wd/index_page.html',
 			'/wd/search_page.html',
 			'/wd/gene_list.html',
 			'/wd/gene.html',
@@ -32,6 +33,7 @@ $(document).ready ( function () {
 	] )	.then ( () => {
 			wd_link_wd = wd ;
 			const routes = [
+			  { path: '/', component: IndexPage , props:true },
 			  { path: '/wd', component: MainPage , props:true },
 			  { path: '/gene/:genedb_id', component: Gene , props:true },
 			  { path: '/go/:go_term', component: GoTerm , props:true },


### PR DESCRIPTION
This moves the contents of index.html to a vue.js component, which harmonizes the code a bit. I also abstracted the "species group" boxes, which get now generated from `data/datasets.json` and a bit of hardcoded data (e.g. group names and images; this could go into `data/datasets.json` as well, but I don't know if/how that's curated).

Demo at https://genedb.dev.sanger.ac.uk/